### PR TITLE
feat: added support for custom serveo ssh port

### DIFF
--- a/serveo/README.md
+++ b/serveo/README.md
@@ -47,6 +47,8 @@ Forwarding HTTP traffic from https://myfancyalias.serveo.net
 
 `server` - in case you are using your own serveo instance, put its hostname here
 
+`ssh_port` - in case your custom serveo instance is running on port other than default ssh port (i.e. 22), put it here
+
 `port1from` - local hassio port to forward from, default `8123` forwards frontend service
 
 `port1to` - remote serveo port to forward to, default `80` translate to 443 (https) 
@@ -66,6 +68,7 @@ Forwarding HTTP traffic from https://myfancyalias.serveo.net
     "alias": "myfancysubdomain",
     "private_key": "",
     "server": "serveo.net",
+    "ssh_port": 22,
     "port1from": 8123,
     "port1to": 80,
     "port2from": 0,

--- a/serveo/config.json
+++ b/serveo/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Serveo Free Reverse SSL Proxy",
-  "version": "0.8",
+  "version": "0.9",
   "slug": "serveo",
   "description": "Expose Your hassio to the internet through SSL/HTTPS with one click thanks to SERVEO.net. You DO NOT need to: have external IP, make any router configuration (no need to forward any port), create any logins (DuckDNS and others dynamic DNS services require all this hassle).",
   "url": "https://github.com/lechup/hassio-addons/tree/master/serveo",
@@ -12,6 +12,7 @@
     "alias": null,
     "private_key": null,
     "server": "serveo.net",
+    "ssh_port": 22,
     "port1from": 8123,
     "port1to": 80,
     "port2from": 0,
@@ -25,6 +26,7 @@
     "alias": "str",
     "private_key": "str",
     "server": "str",
+    "ssh_port": "int",
     "port1from": "int",
     "port1to": "int",
     "port2from": "int",

--- a/serveo/run.sh
+++ b/serveo/run.sh
@@ -6,6 +6,7 @@ CONFIG_PATH=/data/options.json
 ALIAS="$(jq --raw-output '.alias' ${CONFIG_PATH})"
 PRIVATE_KEY="$(jq --raw-output '.private_key' ${CONFIG_PATH})"
 SERVER="$(jq --raw-output '.server' ${CONFIG_PATH})"
+SSH_PORT="$(jq --raw-output '.ssh_port' ${CONFIG_PATH})"
 DOMAIN="$(jq --raw-output '.domain' ${CONFIG_PATH})"
 PORT1FROM="$(jq --raw-output '.port1from' ${CONFIG_PATH})"
 PORT1TO="$(jq --raw-output '.port1to' ${CONFIG_PATH})"
@@ -34,6 +35,7 @@ PORT1="-R ${DOMAIN}:${PORT1TO}:localhost:${PORT1FROM}"
 PORT2=""
 PORT3=""
 
+SSH_PORT_PARAM=""
 
 if [ "${PORT2FROM}" != "0" ] && [ "${PORT2TO}" != "0" ]
 then
@@ -45,7 +47,12 @@ then
     PORT3=" -R  ${DOMAIN}:${PORT3TO}:localhost:${PORT3FROM}"
 fi
 
-CMD="/bin/bash -c 'sleep ${RETRY_TIME} && ssh ${IDENTITY} -tt -o ExitOnForwardFailure=yes -o StrictHostKeyChecking=no -o ServerAliveInterval=10 -o ServerAliveCountMax=3 ${PORT1}${PORT2}${PORT3} ${ALIAS}@${SERVER}'"
+if [ "${SSH_PORT}" != "0" ]
+then
+    SSH_PORT_PARAM=" -p ${SSH_PORT}"
+fi
+
+CMD="/bin/bash -c 'sleep ${RETRY_TIME} && ssh ${IDENTITY} -tt -o ExitOnForwardFailure=yes -o StrictHostKeyChecking=no -o ServerAliveInterval=10 -o ServerAliveCountMax=3 ${PORT1}${PORT2}${PORT3} ${ALIAS}@${SERVER}${SSH_PORT_PARAM}'"
 
 echo "Running '${CMD}' through supervisor!"
 


### PR DESCRIPTION
This PR includes added support to mention custom SSH port incase the custom serveo instance is running on a port other than default SSH port, which is 22. Fixes #3